### PR TITLE
SkySQL Cloud, [MTST-288]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MariaDB SkySQL Terraform Provider
+# SkySQL Terraform Provider
 
-> The MariaDB SkySQL Terraform Provider is a Technical Preview. Software in Tech Preview should not be used for production workloads.
+> The SkySQL Terraform Provider is a Technical Preview. Software in Tech Preview should not be used for production workloads.
 
-This is a Terraform provider for managing resources in [MariaDB SkySQL](https://mariadb.com/products/skysql/).
+This is a Terraform provider for managing resources in [SkySQL](https://www.skysql.com).
 
 See the examples in `/docs` in this repository for usage examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
-page_title: "MariaDB SkySQL Terraform Provider"
+page_title: "SkySQL Terraform Provider"
 description: |-
-   The MariaDB SkySQL Terraform Provider allows database services in MariaDB SkySQL to be managed using Terraform.
+   The SkySQL Terraform Provider allows database services in SkySQL to be managed using Terraform.
 ---
 
 # SKYSQL Provider
@@ -14,7 +14,7 @@ The provider allows configuring any SkySQL DB topology using the Terraform's dec
 
 [Terraform](https://www.terraform.io/) is an open source infrastructure-as-code (IaC) utility.
 
-Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://skysql.mariadb.com/dashboard) or the SkySQL REST API.
+Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://app.skysql.com/dashboard) or the SkySQL REST API.
 
 Use the navigation to the left to read about the available resources.
 
@@ -89,14 +89,14 @@ The following examples use Bash on Linux (x64).
 3. Copy the plugin to a target system and move to the Terraform plugins directory.
 
     ```console
-    mv terraform-provider-skysql_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql
+    mv terraform-provider-skysql_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql/
 
     ```
 
 4. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/skysql/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql/
     ```
 
 #### macOS
@@ -137,7 +137,7 @@ The following example uses Bash (default) on macOS (ARM).
 5. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/skysql/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql/
     ```
 
 ## Configure the Terraform Configuration Files
@@ -294,24 +294,14 @@ If you agree with the changes, run `terraform apply` to create the service.
 
 Obtain the connection credentials for the new SkySQL service by executing the following commands:
 
-1. Download [skysql_chain_2022.pem](https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem), which contains the Certificate Authority chain that is used to verify the server's certificate for TLS:
-
-```bash
-$ curl https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem --output ~/Downloads/skysql_chain_2022.pem
-```
-
-2. Obtain the connection command from the terraform.tfstate file:
-
+1. Obtain the connection command from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_cmd" terraform.tfstate
 ```
-3. Obtain the user password from the terraform.tfstate file:
 
+2. Obtain the user password from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
-```
-```bash
-"..password string.."
 ```
 
 ## Connect to the SkySQL service
@@ -319,7 +309,7 @@ $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
 Connect to the SkySQL service by executing the connection command from the previous step:
 
 ```bash
-$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-ca ~/Downloads/skysql_chain_2022.pem
+$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-verify-server-cert
 ```
 
 When prompted, type the password and press enter to connect:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,7 +65,7 @@ func getEnv(key, fallback string) string {
 
 func (p *skySQLProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	accessToken := os.Getenv("TF_SKYSQL_API_ACCESS_TOKEN")
-	baseURL := getEnv("TF_SKYSQL_API_BASE_URL", "https://api.mariadb.com")
+	baseURL := getEnv("TF_SKYSQL_API_BASE_URL", "https://api.skysql.com")
 
 	var data SkySQLProviderModel
 

--- a/internal/provider/service_resource_privatlink_test.go
+++ b/internal/provider/service_resource_privatlink_test.go
@@ -119,7 +119,7 @@ func TestServiceResourcePrivateLink(t *testing.T) {
 		service.Endpoints[0].Mechanism = "privatelink"
 		service.Endpoints[0].AllowedAccounts = []string{"mdb-cnewport"}
 		service.Endpoints[0].Visibility = "private"
-		service.Endpoints[0].EndpointService = "privatelink.mariadb.com"
+		service.Endpoints[0].EndpointService = "privatelink.skysql.com"
 		json.NewEncoder(w).Encode(&provisioning.PatchServiceEndpointsResponse{
 			{
 				Mechanism:       service.Endpoints[0].Mechanism,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,7 +1,7 @@
 ---
-page_title: "MariaDB SkySQL Terraform Provider"
+page_title: "SkySQL Terraform Provider"
 description: |-
-   The MariaDB SkySQL Terraform Provider allows database services in MariaDB SkySQL to be managed using Terraform.
+   The SkySQL Terraform Provider allows database services in SkySQL to be managed using Terraform.
 ---
 
 # {{ .ProviderShortName | upper }} Provider
@@ -14,7 +14,7 @@ The provider allows configuring any SkySQL DB topology using the Terraform's dec
 
 [Terraform](https://www.terraform.io/) is an open source infrastructure-as-code (IaC) utility.
 
-Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://skysql.mariadb.com/dashboard) or the SkySQL REST API.
+Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://app.skysql.com/dashboard) or the SkySQL REST API.
 
 Use the navigation to the left to read about the available resources.
 
@@ -89,14 +89,14 @@ The following examples use Bash on Linux (x64).
 3. Copy the plugin to a target system and move to the Terraform plugins directory.
 
     ```console
-    mv {{.ProviderName}}_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}
+    mv {{.ProviderName}}_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
 
     ```
 
 4. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/{{.ProviderShortName}}/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
     ```
 
 #### macOS
@@ -137,7 +137,7 @@ The following example uses Bash (default) on macOS (ARM).
 5. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/{{.ProviderShortName}}/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
     ```
 
 ## Configure the Terraform Configuration Files
@@ -221,24 +221,14 @@ If you agree with the changes, run `terraform apply` to create the service.
 
 Obtain the connection credentials for the new SkySQL service by executing the following commands:
 
-1. Download [skysql_chain_2022.pem](https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem), which contains the Certificate Authority chain that is used to verify the server's certificate for TLS:
-
-```bash
-$ curl https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem --output ~/Downloads/skysql_chain_2022.pem
-```
-
-2. Obtain the connection command from the terraform.tfstate file:
-
+1. Obtain the connection command from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_cmd" terraform.tfstate
 ```
-3. Obtain the user password from the terraform.tfstate file:
 
+2. Obtain the user password from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
-```
-```bash
-"..password string.."
 ```
 
 ## Connect to the SkySQL service
@@ -246,7 +236,7 @@ $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
 Connect to the SkySQL service by executing the connection command from the previous step:
 
 ```bash
-$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-ca ~/Downloads/skysql_chain_2022.pem
+$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-verify-server-cert
 ```
 
 When prompted, type the password and press enter to connect:


### PR DESCRIPTION
Follow up to [beta PR](https://github.com/skysqlinc/terraform-provider-skysql-beta/pull/2)

Tested with the following provider tag:
```
terraform {
  required_providers {
    skysql = {
      source = "registry.terraform.io/skysqlinc/skysql"
      version = ">= 2.0.0"
    }
  }
}
```

Available in the dashboard

![image](https://github.com/skysqlinc/terraform-provider-skysql/assets/156709221/f134615d-06f6-4156-8150-6229bc1da886)
