### PR TITLE
MCDEV-4132: fail fast when serverless-standalone is not offered to the org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Creating a `serverless-standalone` service now fails fast with a clear error when the topology is not offered to the calling organization (for example BYOA organizations), instead of surfacing a raw API error at apply time (MCDEV-4132).
 
+### Added
+- BYOA documentation: a [Bring Your Own Account guide](docs/guides/byoa.md) and a runnable [`examples/byoa`](examples/byoa) example covering topology restrictions, endpoint defaults, and region availability for BYOA organizations.
+
 ## [3.5.5] - 2026-06-17
 ### Fixed
 - Concurrent service operations (for example a config change and a scaling operation) no longer conflict. When the API rejects a mutation because the service is in a transient `pending_*` state, the provider now waits for the service to become modifiable and retries instead of failing the apply (MCDEV-3899).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.5.6] - 2026-07-15
+### Fixed
+- Creating a `serverless-standalone` service now fails fast with a clear error when the topology is not offered to the calling organization (for example BYOA organizations), instead of surfacing a raw API error at apply time (MCDEV-4132).
+
 ## [3.5.5] - 2026-06-17
 ### Fixed
 - Concurrent service operations (for example a config change and a scaling operation) no longer conflict. When the API rejects a mutation because the service is in a transient `pending_*` state, the provider now waits for the service to become modifiable and retries instead of failing the apply (MCDEV-3899).

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ go install
 See the [documentation](docs/) for usage examples and detailed guides, including:
 
 - [Multi-Organization Support](docs/guides/multi-organization-support.md) - Managing services across multiple SkySQL organizations
+- [Bring Your Own Account (BYOA)](docs/guides/byoa.md) - Using the provider with a BYOA organization

--- a/docs/guides/byoa.md
+++ b/docs/guides/byoa.md
@@ -6,36 +6,17 @@ description: |-
 
 # Bring Your Own Account (BYOA)
 
-In a BYOA (Bring Your Own Account) organization, SkySQL deploys database services into your own cloud account instead of SkySQL-managed infrastructure. BYOA is enabled per organization and per cloud provider by the SkySQL team — there is nothing to configure in the provider itself. The API recognizes a BYOA organization from your API key and applies the rules below automatically.
+In a BYOA organization, MariaDB Cloud deploys database services into your own cloud account instead of MariaDB Cloud's own infrastructure. BYOA is enabled for an organization by the MariaDB Cloud team, per cloud provider. There is nothing to configure in the provider itself: the API recognizes a BYOA organization from your API key and applies BYOA behavior automatically.
 
-## What is different for a BYOA organization
+Most things work exactly as they do in any other organization. A few don't, and they matter when writing Terraform.
 
-### Topologies
+Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with `The "serverless-standalone" topology is not available for your organization.` Use a provisioned topology such as `es-single` or `es-replica` instead.
 
-Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with:
+Endpoints are private by default. If you don't configure an IP `allow_list`, the service comes up with a private `privateconnect` endpoint — so set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly, otherwise your configuration says one thing and the created service another. If you do configure an `allow_list`, the service gets a public endpoint restricted to those addresses. The API will not let a BYOA endpoint become a public `nlb` endpoint without a non-empty allow list.
 
-```
-The "serverless-standalone" topology is not available for your organization.
-```
+Two smaller points: services always run on dedicated tenancy in your cloud account regardless of configuration, and only the regions enabled for your BYOA account during onboarding are available.
 
-Use provisioned topologies such as `es-single` or `es-replica` instead.
-
-### Tenancy
-
-BYOA services always run on dedicated tenancy in your cloud account. The API enforces this regardless of configuration.
-
-### Endpoints
-
-BYOA services default to private connectivity:
-
-- Without an IP `allow_list`, the service is created with a private `privateconnect` endpoint. Set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so your configuration matches what the API creates.
-- With an IP `allow_list`, the service is created with a public endpoint restricted to those addresses. The API rejects switching a BYOA endpoint to a public `nlb` endpoint without a non-empty allow list.
-
-### Regions
-
-Only the regions enabled for your BYOA account during onboarding are available to your organization.
-
-## Example
+A typical BYOA service looks like this:
 
 ```hcl
 provider "skysql" {}
@@ -64,4 +45,4 @@ resource "skysql_service" "this" {
 }
 ```
 
-A complete runnable example is available in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.
+A complete runnable version of this is in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.

--- a/docs/guides/byoa.md
+++ b/docs/guides/byoa.md
@@ -1,0 +1,67 @@
+---
+page_title: "Bring Your Own Account (BYOA)"
+description: |-
+  Using the provider with a BYOA organization
+---
+
+# Bring Your Own Account (BYOA)
+
+In a BYOA (Bring Your Own Account) organization, SkySQL deploys database services into your own cloud account instead of SkySQL-managed infrastructure. BYOA is enabled per organization and per cloud provider by the SkySQL team — there is nothing to configure in the provider itself. The API recognizes a BYOA organization from your API key and applies the rules below automatically.
+
+## What is different for a BYOA organization
+
+### Topologies
+
+Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with:
+
+```
+The "serverless-standalone" topology is not available for your organization.
+```
+
+Use provisioned topologies such as `es-single` or `es-replica` instead.
+
+### Tenancy
+
+BYOA services always run on dedicated tenancy in your cloud account. The API enforces this regardless of configuration.
+
+### Endpoints
+
+BYOA services default to private connectivity:
+
+- Without an IP `allow_list`, the service is created with a private `privateconnect` endpoint. Set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so your configuration matches what the API creates.
+- With an IP `allow_list`, the service is created with a public endpoint restricted to those addresses. The API rejects switching a BYOA endpoint to a public `nlb` endpoint without a non-empty allow list.
+
+### Regions
+
+Only the regions enabled for your BYOA account during onboarding are available to your organization.
+
+## Example
+
+```hcl
+provider "skysql" {}
+
+data "aws_caller_identity" "this" {}
+
+data "skysql_versions" "this" {
+  topology = "es-single"
+}
+
+resource "skysql_service" "this" {
+  service_type              = "transactional"
+  topology                  = "es-single"
+  cloud_provider            = "aws"
+  region                    = "us-east-1"
+  name                      = "my-byoa-database"
+  architecture              = "amd64"
+  nodes                     = 1
+  size                      = "sky-2x8"
+  storage                   = 100
+  ssl_enabled               = true
+  version                   = data.skysql_versions.this.versions[0].name
+  endpoint_mechanism        = "privateconnect"
+  endpoint_allowed_accounts = [data.aws_caller_identity.this.account_id]
+  wait_for_creation         = true
+}
+```
+
+A complete runnable example is available in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.

--- a/examples/byoa/README.md
+++ b/examples/byoa/README.md
@@ -1,13 +1,8 @@
 # BYOA (Bring Your Own Account) Example
 
-This example creates a provisioned SkySQL service in a BYOA organization. BYOA is enabled per organization and per cloud provider by the SkySQL team; the provider needs no special configuration — the API detects a BYOA organization from the API key.
+This example creates a provisioned MariaDB Cloud service in a BYOA organization — one where services are deployed into your own cloud account rather than MariaDB Cloud's own infrastructure. BYOA is enabled for an organization by the MariaDB Cloud team, and the provider needs no special configuration: the API detects a BYOA organization from the API key.
 
-## What the API enforces for BYOA organizations
-
-- The service is deployed into your own cloud account on dedicated tenancy.
-- Endpoints default to private connectivity. This example sets `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so the configuration matches what is created.
-- The `serverless-standalone` topology is not available. Use provisioned topologies such as `es-single` or `es-replica`.
-- Only regions enabled for your BYOA account during onboarding can be used.
+Two things to know when writing Terraform for a BYOA organization. Serverless is not available — `serverless-standalone` is rejected, so use a provisioned topology such as `es-single` or `es-replica`. And endpoints are private by default: this example sets `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so the configuration matches what is actually created. Services run on dedicated tenancy in your account, and only the regions enabled for your BYOA account during onboarding can be used.
 
 ## Usage
 
@@ -17,6 +12,4 @@ terraform init
 terraform apply -var skysql_service_name="my-byoa-database"
 ```
 
-To connect through the private endpoint from your VPC, see the [`privateconnect`](../privateconnect) (AWS PrivateLink), [`azure-private-link`](../azure-private-link), and [`private-service-connect`](../private-service-connect) (GCP) examples.
-
-See also the [BYOA guide](../../docs/guides/byoa.md).
+To connect through the private endpoint from your VPC, see the [`privateconnect`](../privateconnect) (AWS PrivateLink), [`azure-private-link`](../azure-private-link), and [`private-service-connect`](../private-service-connect) (GCP) examples. There is also a [BYOA guide](../../docs/guides/byoa.md) with more detail.

--- a/examples/byoa/README.md
+++ b/examples/byoa/README.md
@@ -1,0 +1,22 @@
+# BYOA (Bring Your Own Account) Example
+
+This example creates a provisioned SkySQL service in a BYOA organization. BYOA is enabled per organization and per cloud provider by the SkySQL team; the provider needs no special configuration — the API detects a BYOA organization from the API key.
+
+## What the API enforces for BYOA organizations
+
+- The service is deployed into your own cloud account on dedicated tenancy.
+- Endpoints default to private connectivity. This example sets `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so the configuration matches what is created.
+- The `serverless-standalone` topology is not available. Use provisioned topologies such as `es-single` or `es-replica`.
+- Only regions enabled for your BYOA account during onboarding can be used.
+
+## Usage
+
+```shell
+export TF_SKYSQL_API_KEY="..."
+terraform init
+terraform apply -var skysql_service_name="my-byoa-database"
+```
+
+To connect through the private endpoint from your VPC, see the [`privateconnect`](../privateconnect) (AWS PrivateLink), [`azure-private-link`](../azure-private-link), and [`private-service-connect`](../private-service-connect) (GCP) examples.
+
+See also the [BYOA guide](../../docs/guides/byoa.md).

--- a/examples/byoa/main.tf
+++ b/examples/byoa/main.tf
@@ -5,14 +5,13 @@ data "skysql_versions" "this" {
 }
 
 ###
-# Create a SkySQL service in a BYOA (Bring Your Own Account) organization.
+# Create a MariaDB Cloud service in a BYOA (Bring Your Own Account)
+# organization. The API detects a BYOA organization automatically: the service
+# is deployed into your own cloud account, runs on dedicated tenancy, and
+# endpoints default to private connectivity.
 #
-# The API detects a BYOA organization automatically: the service is deployed
-# into your own cloud account, runs on dedicated tenancy, and endpoints
-# default to private connectivity.
-#
-# Note: the serverless-standalone topology is not available for BYOA
-# organizations. Use provisioned topologies such as es-single or es-replica.
+# The serverless-standalone topology is not available for BYOA organizations;
+# use a provisioned topology such as es-single or es-replica.
 ###
 resource "skysql_service" "this" {
   service_type              = "transactional"

--- a/examples/byoa/main.tf
+++ b/examples/byoa/main.tf
@@ -1,0 +1,41 @@
+data "aws_caller_identity" "this" {}
+
+data "skysql_versions" "this" {
+  topology = var.topology
+}
+
+###
+# Create a SkySQL service in a BYOA (Bring Your Own Account) organization.
+#
+# The API detects a BYOA organization automatically: the service is deployed
+# into your own cloud account, runs on dedicated tenancy, and endpoints
+# default to private connectivity.
+#
+# Note: the serverless-standalone topology is not available for BYOA
+# organizations. Use provisioned topologies such as es-single or es-replica.
+###
+resource "skysql_service" "this" {
+  service_type              = "transactional"
+  topology                  = var.topology
+  cloud_provider            = "aws"
+  region                    = var.region
+  name                      = var.skysql_service_name
+  architecture              = "amd64"
+  nodes                     = 1
+  size                      = "sky-2x8"
+  storage                   = 100
+  ssl_enabled               = true
+  version                   = data.skysql_versions.this.versions[0].name
+  endpoint_mechanism        = "privateconnect"
+  endpoint_allowed_accounts = [data.aws_caller_identity.this.account_id]
+  wait_for_creation         = true
+  volume_type               = "gp3"
+  volume_iops               = 3000
+  volume_throughput         = 125
+  # The following line will be required when tearing down the skysql service
+  # deletion_protection = false
+}
+
+data "skysql_service" "this" {
+  service_id = skysql_service.this.id
+}

--- a/examples/byoa/providers.tf
+++ b/examples/byoa/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    skysql = {
+      source = "registry.terraform.io/skysqlinc/skysql"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.55.0"
+    }
+  }
+}
+
+provider "skysql" {}
+provider "aws" {
+  region = var.region
+}

--- a/examples/byoa/variables.tf
+++ b/examples/byoa/variables.tf
@@ -1,5 +1,5 @@
 variable "topology" {
-  description = "SkySQL topology type to deploy. Serverless topologies are not available for BYOA organizations."
+  description = "Topology to deploy. Serverless topologies are not available for BYOA organizations."
   type        = string
   default     = "es-single"
 }
@@ -11,6 +11,6 @@ variable "region" {
 }
 
 variable "skysql_service_name" {
-  description = "Name of the skysql service being created"
+  description = "Name of the service being created"
   type        = string
 }

--- a/examples/byoa/variables.tf
+++ b/examples/byoa/variables.tf
@@ -1,0 +1,16 @@
+variable "topology" {
+  description = "SkySQL topology type to deploy. Serverless topologies are not available for BYOA organizations."
+  type        = string
+  default     = "es-single"
+}
+
+variable "region" {
+  description = "AWS region. Must be enabled for your BYOA account."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "skysql_service_name" {
+  description = "Name of the skysql service being created"
+  type        = string
+}

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -608,6 +608,29 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	// The topologies endpoint is organization-aware: topologies the calling
+	// organization cannot launch (e.g. serverless for BYOA) are absent from it.
+	if createServiceRequest.Topology == "serverless-standalone" {
+		topologies, err := r.client.GetTopologies(ctx)
+		if err != nil {
+			tflog.Warn(ctx, "unable to verify topology availability, deferring to the create API: "+err.Error())
+		} else {
+			offered := false
+			for _, topology := range topologies {
+				if topology.Name == createServiceRequest.Topology {
+					offered = true
+					break
+				}
+			}
+			if !offered {
+				resp.Diagnostics.AddAttributeError(path.Root("topology"),
+					"Topology not available",
+					fmt.Sprintf("The %q topology is not available for your organization.", createServiceRequest.Topology))
+				return
+			}
+		}
+	}
+
 	service, err := r.client.CreateService(ctx, createServiceRequest)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating service", err.Error())

--- a/internal/provider/service_resource_serverless_standalone_test.go
+++ b/internal/provider/service_resource_serverless_standalone_test.go
@@ -36,6 +36,16 @@ func TestServiceResourceServerlessStandalone_IsActiveReadOnly(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode([]provisioning.Version{})
 	})
+	// Topology availability pre-check for serverless-standalone
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodGet, req.Method)
+		r.Equal("/provisioning/v1/topologies", req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]provisioning.Topology{
+			{Name: "serverless-standalone", ServiceType: "transactional_serverless"},
+		})
+	})
 	var service *provisioning.Service
 	// Create service
 	expectRequest(func(w http.ResponseWriter, req *http.Request) {
@@ -224,6 +234,68 @@ func TestServiceResourceServerlessStandalone_IsActiveReadOnly(t *testing.T) {
 			}
 			   `,
 				ExpectError: regexp.MustCompile(`Start/stop operations are not supported for serverless services`),
+				Destroy:     false,
+			},
+		},
+	})
+}
+
+func TestServiceResourceServerlessStandalone_NotAvailableForOrg(t *testing.T) {
+	testUrl, expectRequest, closeAPI := mockSkySQLAPI(t)
+	defer closeAPI()
+	os.Setenv("TF_SKYSQL_API_KEY", "[api-key]")
+	os.Setenv("TF_SKYSQL_API_BASE_URL", testUrl)
+
+	r := require.New(t)
+
+	configureOnce.Reset()
+	// Check API connectivity
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodGet, req.Method)
+		r.Equal("/provisioning/v1/versions", req.URL.Path)
+		r.Equal("page_size=1", req.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]provisioning.Version{})
+	})
+	// Topology availability pre-check: the organization (e.g. BYOA) is not
+	// offered serverless-standalone, so the create must fail before the POST.
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodGet, req.Method)
+		r.Equal("/provisioning/v1/topologies", req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]provisioning.Topology{
+			{Name: "es-single", ServiceType: "transactional"},
+			{Name: "es-replica", ServiceType: "transactional"},
+		})
+	})
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"skysql": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+			resource "skysql_service" default {
+				  service_type      = "transactional"
+				  topology          = "serverless-standalone"
+				  cloud_provider    = "aws"
+				  region            = "us-east-1"
+				  name              = "sls-standalone-test"
+				  wait_for_creation = true
+				  wait_for_deletion = true
+				  wait_for_update   = true
+				  deletion_protection = false
+				  ssl_enabled       = true
+				  size              = "sky-2x8"
+				  storage           = 100
+				  volume_type       = "io1"
+				  volume_iops       = 3000
+			}
+			   `,
+				ExpectError: regexp.MustCompile(`is not available for your organization`),
 				Destroy:     false,
 			},
 		},

--- a/internal/skysql/client.go
+++ b/internal/skysql/client.go
@@ -127,6 +127,27 @@ func (c *Client) GetVersions(ctx context.Context, options ...func(url.Values)) (
 	return *resp.Result().(*[]provisioning.Version), err
 }
 
+func (c *Client) GetTopologies(ctx context.Context, options ...func(url.Values)) ([]provisioning.Topology, error) {
+	request := c.HTTPClient.R()
+	for _, option := range options {
+		option(request.QueryParam)
+	}
+	resp, err := request.
+		SetHeader("Accept", "application/json").
+		SetResult([]provisioning.Topology{}).
+		SetError(&ErrorResponse{}).
+		SetContext(ctx).
+		Get("/provisioning/v1/topologies")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.IsError() {
+		return nil, handleError(resp)
+	}
+	return *resp.Result().(*[]provisioning.Topology), err
+}
+
 func (c *Client) GetServiceByID(ctx context.Context, serviceID string) (*provisioning.Service, error) {
 	resp, err := c.HTTPClient.R().
 		SetHeader("Accept", "application/json").

--- a/internal/skysql/provisioning/topology.go
+++ b/internal/skysql/provisioning/topology.go
@@ -1,0 +1,12 @@
+package provisioning
+
+type Topology struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	DisplayName   string `json:"display_name,omitempty"`
+	ServiceType   string `json:"service_type"`
+	StorageEngine string `json:"storage_engine,omitempty"`
+	Order         int    `json:"order,omitempty"`
+	IsDefault     bool   `json:"is_default"`
+	Database      string `json:"database,omitempty"`
+}

--- a/templates/guides/byoa.md
+++ b/templates/guides/byoa.md
@@ -6,36 +6,17 @@ description: |-
 
 # Bring Your Own Account (BYOA)
 
-In a BYOA (Bring Your Own Account) organization, SkySQL deploys database services into your own cloud account instead of SkySQL-managed infrastructure. BYOA is enabled per organization and per cloud provider by the SkySQL team — there is nothing to configure in the provider itself. The API recognizes a BYOA organization from your API key and applies the rules below automatically.
+In a BYOA organization, MariaDB Cloud deploys database services into your own cloud account instead of MariaDB Cloud's own infrastructure. BYOA is enabled for an organization by the MariaDB Cloud team, per cloud provider. There is nothing to configure in the provider itself: the API recognizes a BYOA organization from your API key and applies BYOA behavior automatically.
 
-## What is different for a BYOA organization
+Most things work exactly as they do in any other organization. A few don't, and they matter when writing Terraform.
 
-### Topologies
+Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with `The "serverless-standalone" topology is not available for your organization.` Use a provisioned topology such as `es-single` or `es-replica` instead.
 
-Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with:
+Endpoints are private by default. If you don't configure an IP `allow_list`, the service comes up with a private `privateconnect` endpoint — so set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly, otherwise your configuration says one thing and the created service another. If you do configure an `allow_list`, the service gets a public endpoint restricted to those addresses. The API will not let a BYOA endpoint become a public `nlb` endpoint without a non-empty allow list.
 
-```
-The "serverless-standalone" topology is not available for your organization.
-```
+Two smaller points: services always run on dedicated tenancy in your cloud account regardless of configuration, and only the regions enabled for your BYOA account during onboarding are available.
 
-Use provisioned topologies such as `es-single` or `es-replica` instead.
-
-### Tenancy
-
-BYOA services always run on dedicated tenancy in your cloud account. The API enforces this regardless of configuration.
-
-### Endpoints
-
-BYOA services default to private connectivity:
-
-- Without an IP `allow_list`, the service is created with a private `privateconnect` endpoint. Set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so your configuration matches what the API creates.
-- With an IP `allow_list`, the service is created with a public endpoint restricted to those addresses. The API rejects switching a BYOA endpoint to a public `nlb` endpoint without a non-empty allow list.
-
-### Regions
-
-Only the regions enabled for your BYOA account during onboarding are available to your organization.
-
-## Example
+A typical BYOA service looks like this:
 
 ```hcl
 provider "skysql" {}
@@ -64,4 +45,4 @@ resource "skysql_service" "this" {
 }
 ```
 
-A complete runnable example is available in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.
+A complete runnable version of this is in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.

--- a/templates/guides/byoa.md
+++ b/templates/guides/byoa.md
@@ -1,0 +1,67 @@
+---
+page_title: "Bring Your Own Account (BYOA)"
+description: |-
+  Using the provider with a BYOA organization
+---
+
+# Bring Your Own Account (BYOA)
+
+In a BYOA (Bring Your Own Account) organization, SkySQL deploys database services into your own cloud account instead of SkySQL-managed infrastructure. BYOA is enabled per organization and per cloud provider by the SkySQL team — there is nothing to configure in the provider itself. The API recognizes a BYOA organization from your API key and applies the rules below automatically.
+
+## What is different for a BYOA organization
+
+### Topologies
+
+Serverless is not available. Creating a service with `topology = "serverless-standalone"` fails with:
+
+```
+The "serverless-standalone" topology is not available for your organization.
+```
+
+Use provisioned topologies such as `es-single` or `es-replica` instead.
+
+### Tenancy
+
+BYOA services always run on dedicated tenancy in your cloud account. The API enforces this regardless of configuration.
+
+### Endpoints
+
+BYOA services default to private connectivity:
+
+- Without an IP `allow_list`, the service is created with a private `privateconnect` endpoint. Set `endpoint_mechanism = "privateconnect"` and `endpoint_allowed_accounts` explicitly so your configuration matches what the API creates.
+- With an IP `allow_list`, the service is created with a public endpoint restricted to those addresses. The API rejects switching a BYOA endpoint to a public `nlb` endpoint without a non-empty allow list.
+
+### Regions
+
+Only the regions enabled for your BYOA account during onboarding are available to your organization.
+
+## Example
+
+```hcl
+provider "skysql" {}
+
+data "aws_caller_identity" "this" {}
+
+data "skysql_versions" "this" {
+  topology = "es-single"
+}
+
+resource "skysql_service" "this" {
+  service_type              = "transactional"
+  topology                  = "es-single"
+  cloud_provider            = "aws"
+  region                    = "us-east-1"
+  name                      = "my-byoa-database"
+  architecture              = "amd64"
+  nodes                     = 1
+  size                      = "sky-2x8"
+  storage                   = 100
+  ssl_enabled               = true
+  version                   = data.skysql_versions.this.versions[0].name
+  endpoint_mechanism        = "privateconnect"
+  endpoint_allowed_accounts = [data.aws_caller_identity.this.account_id]
+  wait_for_creation         = true
+}
+```
+
+A complete runnable example is available in [`examples/byoa`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/byoa). For wiring up the private endpoint on the consumer side, see the [`privateconnect` (AWS PrivateLink)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/privateconnect), [`azure-private-link`](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/azure-private-link), and [`private-service-connect` (GCP)](https://github.com/skysqlinc/terraform-provider-skysql/tree/main/examples/private-service-connect) examples.


### PR DESCRIPTION
Port of skysqlinc/terraform-provider-skysql-beta#37 to the main provider.

## Summary
- Before creating a `serverless-standalone` service, the provider now calls the org-aware `GET /provisioning/v1/topologies` listing and fails with a clear attribute error (`The \"serverless-standalone\" topology is not available for your organization.`) when the topology is not offered — e.g. BYOA organizations, for which DPS filters serverless out of the listing (skysql-microservices#1043)
- Fail-open by design: if the listing call errors, the pre-check is skipped and the create API stays authoritative (DPS returns 400 for BYOA serverless creates)
- The check is scoped to `serverless-standalone` only, so legacy/display-flag-filtered topologies (galera, standalone aliases) are unaffected
- New `GetTopologies` client method + `provisioning.Topology` type
- **BYOA documentation**: new `docs/guides/byoa.md` guide (+ template) and runnable `examples/byoa` covering topology restrictions, dedicated tenancy, private-by-default endpoints, and region availability; linked from README
- CHANGELOG bumped to 3.5.6

## Test plan
- New `TestServiceResourceServerlessStandalone_NotAvailableForOrg`: topologies listing without serverless → apply fails with the clear error before any POST
- Updated `TestServiceResourceServerlessStandalone_IsActiveReadOnly` mock to expect the new pre-check request
- Full provider suite green locally (`TF_ACC=1 go test ./...`)