### PR TITLE
Support in-place MaxScale node scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.5.7] - 2026-07-17
+### Added
+- `maxscale_nodes` can now be changed in place. The provider applies the change through the service nodes API instead of destroying and recreating the service. Removing the attribute from configuration still forces replacement.
+
 ## [3.5.6] - 2026-07-15
 ### Fixed
 - Creating a `serverless-standalone` service now fails fast with a clear error when the topology is not offered to the calling organization (for example BYOA organizations), instead of surfacing a raw API error at apply time (MCDEV-4132).

--- a/docs/guides/scaling-instance-and-storage.md
+++ b/docs/guides/scaling-instance-and-storage.md
@@ -113,8 +113,36 @@ resource "skysql_service" "default" {
 }
 ```
 
+## Scaling MaxScale Nodes
+
+Replicated topologies that include MaxScale (for example `es-replica` and `galera`) accept a `maxscale_nodes` attribute. Changing its value updates the service in place — for example, going from a single MaxScale node to a redundant pair:
+
+```hcl
+resource "skysql_service" "default" {
+  service_type      = "transactional"
+  topology          = "galera"
+  cloud_provider    = "aws"
+  region            = "us-east-1"
+  name              = "myservice"
+  architecture      = "amd64"
+  nodes             = 3
+  maxscale_nodes    = 2 # was 1
+  maxscale_size     = "sky-2x4"
+  size              = "sky-4x16"
+  storage           = 100
+  ssl_enabled       = true
+  version           = "10.6"
+  wait_for_creation = true
+  wait_for_update   = true
+}
+```
+
+A `maxscale_nodes` change can be combined with a `nodes` change in the same apply; the provider submits them as a single scaling request.
+
+~> **Note:** Valid values are 1 or 2, and MaxScale changes require the Power tier — the same rules that apply when configuring MaxScale at creation. Removing `maxscale_nodes` from the configuration entirely forces the service to be replaced, as does changing `maxscale_size`.
+
 ## Important Notes
 
 - **Set `wait_for_update = true`** to ensure Terraform waits for each scaling operation to complete before proceeding. Without this, Terraform will return immediately after submitting the request.
 - **Scaling is an online operation** — the service remains accessible during scaling, though brief performance impact may occur.
-- **Node count scaling** is also supported via the `nodes` attribute and can be combined with size and storage changes in the same apply.
+- **Node count scaling** is also supported via the `nodes` attribute and can be combined with size, storage, and MaxScale node changes in the same apply.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -91,7 +91,7 @@ resource "skysql_service" "galera" {
 - `endpoint_allowed_accounts` (List of String) The list of cloud accounts (aws, azure, or gcp projects) that are allowed to access the service. Works only with `privateconnect` endpoint mechanism
 - `endpoint_mechanism` (String) The endpoint mechanism to use. Valid values are: privateconnect or nlb
 - `is_active` (Boolean) Whether the service is active
-- `maxscale_nodes` (Number) The number of MaxScale nodes
+- `maxscale_nodes` (Number) The number of MaxScale nodes. Changing the value updates the service in place; removing the attribute forces the service to be replaced
 - `maxscale_size` (String) The size of the MaxScale nodes. Valid values are: sky-2x4, sky-2x8 etc
 - `nodes` (Number) The number of nodes
 - `nosql_enabled` (Boolean) Whether to enable NoSQL. Valid values are: true or false

--- a/examples/galera-cluster/README.md
+++ b/examples/galera-cluster/README.md
@@ -45,7 +45,7 @@ This example demonstrates how to create a Galera Cluster service using the SkySQ
 
 To scale your Galera cluster:
 - You can increase nodes from 3 to 5
-- You can scale MaxScale nodes from 1 to 2
+- You can scale MaxScale nodes from 1 to 2 — `maxscale_nodes` changes are applied in place, without recreating the cluster
 - You can upgrade instance size (e.g., sky-4x16 to sky-8x32)
 - You can increase storage capacity
 

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -419,9 +419,15 @@ var serviceResourceSchemaV0 = schema.Schema{
 		},
 		"maxscale_nodes": schema.Int64Attribute{
 			Optional:    true,
-			Description: "The number of MaxScale nodes",
+			Description: "The number of MaxScale nodes. Changing the value updates the service in place; removing the attribute forces the service to be replaced",
 			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.RequiresReplace(),
+				int64planmodifier.RequiresReplaceIf(
+					func(ctx context.Context, req planmodifier.Int64Request, resp *int64planmodifier.RequiresReplaceIfFuncResponse) {
+						resp.RequiresReplace = req.ConfigValue.IsNull() && !req.StateValue.IsNull()
+					},
+					"Removing maxscale_nodes forces service replacement; changing its value updates the service in place.",
+					"Removing `maxscale_nodes` forces service replacement; changing its value updates the service in place.",
+				),
 				int64planmodifier.UseStateForUnknown(),
 			},
 		},
@@ -1032,26 +1038,45 @@ func (r *ServiceResource) updateServiceStorage(ctx context.Context, plan *Servic
 }
 
 func (r *ServiceResource) updateNumberOfNodeForService(ctx context.Context, plan *ServiceResourceModel, state *ServiceResourceModel, resp *resource.UpdateResponse) {
-	if plan.Nodes.ValueInt64() != state.Nodes.ValueInt64() {
-		tflog.Info(ctx, "Updating number of nodes for the service", map[string]interface{}{
-			"id":   state.ID.ValueString(),
-			"from": state.Nodes.ValueInt64(),
-			"to":   plan.Nodes.ValueInt64(),
-		})
+	nodesChanged := plan.Nodes.ValueInt64() != state.Nodes.ValueInt64()
+	maxscaleNodesChanged := !plan.MaxscaleNodes.IsNull() && !plan.MaxscaleNodes.IsUnknown() &&
+		plan.MaxscaleNodes.ValueInt64() != state.MaxscaleNodes.ValueInt64()
 
-		err := r.client.ModifyServiceNodeNumber(ctx, state.ID.ValueString(), plan.Nodes.ValueInt64())
-		if err != nil {
-			resp.Diagnostics.AddError("Error updating a number of nodes for the service", fmt.Sprintf("Unable to update a nodes number for the service, got error: %s", err))
-			return
-		}
-
-		state.Nodes = plan.Nodes
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		r.waitForUpdate(ctx, state, resp)
+	if !nodesChanged && !maxscaleNodesChanged {
+		return
 	}
+
+	request := &provisioning.UpdateServiceNodesNumberRequest{}
+	if nodesChanged {
+		request.Nodes = plan.Nodes.ValueInt64()
+	}
+	if maxscaleNodesChanged {
+		request.MaxscaleNodes = toPtr[int64](plan.MaxscaleNodes.ValueInt64())
+	}
+
+	tflog.Info(ctx, "Updating number of nodes for the service", map[string]interface{}{
+		"id":                state.ID.ValueString(),
+		"from":              state.Nodes.ValueInt64(),
+		"to":                plan.Nodes.ValueInt64(),
+		"maxscaleNodesFrom": state.MaxscaleNodes.ValueInt64(),
+		"maxscaleNodesTo":   plan.MaxscaleNodes.ValueInt64(),
+	})
+
+	err := r.client.ModifyServiceNodeNumber(ctx, state.ID.ValueString(), request)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating a number of nodes for the service", fmt.Sprintf("Unable to update a nodes number for the service, got error: %s", err))
+		return
+	}
+
+	state.Nodes = plan.Nodes
+	if maxscaleNodesChanged {
+		state.MaxscaleNodes = plan.MaxscaleNodes
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.waitForUpdate(ctx, state, resp)
 }
 
 func (r *ServiceResource) updateServiceSize(ctx context.Context, plan *ServiceResourceModel, state *ServiceResourceModel, resp *resource.UpdateResponse) {

--- a/internal/provider/service_resource_maxscale_scale_test.go
+++ b/internal/provider/service_resource_maxscale_scale_test.go
@@ -1,0 +1,233 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/skysqlinc/terraform-provider-skysql/internal/skysql"
+	"github.com/skysqlinc/terraform-provider-skysql/internal/skysql/provisioning"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceResourceMaxscaleScale verifies that changing maxscale_nodes
+// updates the service in place through POST /services/{id}/nodes with a
+// maxscale-only payload, instead of destroying and recreating the service.
+func TestServiceResourceMaxscaleScale(t *testing.T) {
+	const serviceID = "dbdgf42002420"
+
+	testUrl, expectRequest, closeAPI := mockSkySQLAPI(t)
+	defer closeAPI()
+	os.Setenv("TF_SKYSQL_API_KEY", "[api-key]")
+	os.Setenv("TF_SKYSQL_API_BASE_URL", testUrl)
+
+	r := require.New(t)
+
+	configureOnce.Reset()
+	var service *provisioning.Service
+	// Check API connectivity
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodGet, req.Method)
+		r.Equal("/provisioning/v1/versions", req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]provisioning.Version{})
+	})
+	// Create service
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodPost, req.Method)
+		r.Equal("/provisioning/v1/services", req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		payload := provisioning.CreateServiceRequest{}
+		err := json.NewDecoder(req.Body).Decode(&payload)
+		r.NoError(err)
+		r.Equal(uint(1), payload.MaxscaleNodes)
+		service = &provisioning.Service{
+			ID:            serviceID,
+			Name:          payload.Name,
+			Region:        payload.Region,
+			Provider:      payload.Provider,
+			Tier:          "power",
+			Topology:      payload.Topology,
+			Version:       payload.Version,
+			Architecture:  payload.Architecture,
+			Size:          payload.Size,
+			Nodes:         int(payload.Nodes),
+			MaxscaleNodes: payload.MaxscaleNodes,
+			MaxscaleSize:  payload.MaxscaleSize,
+			SSLEnabled:    payload.SSLEnabled,
+			Status:        "pending_create",
+			CreatedOn:     int(time.Now().Unix()),
+			UpdatedOn:     int(time.Now().Unix()),
+			CreatedBy:     uuid.New().String(),
+			UpdatedBy:     uuid.New().String(),
+			Endpoints: []provisioning.Endpoint{
+				{
+					Name: "primary",
+					Ports: []provisioning.Port{
+						{
+							Name:    "readwrite",
+							Port:    3306,
+							Purpose: "readwrite",
+						},
+					},
+				},
+			},
+			StorageVolume: struct {
+				Size       int    `json:"size"`
+				VolumeType string `json:"volume_type"`
+				IOPS       int    `json:"iops"`
+				Throughput int    `json:"throughput"`
+			}{
+				Size:       int(payload.Storage),
+				VolumeType: payload.VolumeType,
+				IOPS:       int(payload.VolumeIOPS),
+			},
+			IsActive:    true,
+			ServiceType: payload.ServiceType,
+		}
+		json.NewEncoder(w).Encode(service)
+		w.WriteHeader(http.StatusCreated)
+	})
+	// Get service status
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(http.MethodGet, req.Method)
+		r.Equal("/provisioning/v1/services/"+serviceID, req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		service.Status = "ready"
+		json.NewEncoder(w).Encode(service)
+		w.WriteHeader(http.StatusOK)
+	})
+	// Refresh state
+	for i := 0; i < 3; i++ {
+		expectRequest(func(w http.ResponseWriter, req *http.Request) {
+			r.Equal(
+				fmt.Sprintf("%s %s/%s", http.MethodGet, "/provisioning/v1/services", serviceID),
+				fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+			w.Header().Set("Content-Type", "application/json")
+			service.Status = "ready"
+			json.NewEncoder(w).Encode(service)
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+	// Update maxscale nodes: the payload must carry only maxscale_nodes
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(
+			fmt.Sprintf("%s %s/%s/nodes", http.MethodPost, "/provisioning/v1/services", serviceID),
+			fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+		w.Header().Set("Content-Type", "application/json")
+		payload := &provisioning.UpdateServiceNodesNumberRequest{}
+		err := json.NewDecoder(req.Body).Decode(payload)
+		r.NoError(err)
+		r.Zero(payload.Nodes)
+		r.NotNil(payload.MaxscaleNodes)
+		r.Equal(int64(2), *payload.MaxscaleNodes)
+		service.MaxscaleNodes = uint(*payload.MaxscaleNodes)
+		w.WriteHeader(http.StatusOK)
+	})
+	for i := 0; i < 3; i++ {
+		expectRequest(func(w http.ResponseWriter, req *http.Request) {
+			r.Equal(
+				fmt.Sprintf("%s %s/%s", http.MethodGet, "/provisioning/v1/services", serviceID),
+				fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+			w.Header().Set("Content-Type", "application/json")
+			service.Status = "ready"
+			json.NewEncoder(w).Encode(service)
+			w.WriteHeader(http.StatusOK)
+		})
+	}
+	// Delete service
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(
+			fmt.Sprintf("%s %s/%s", http.MethodDelete, "/provisioning/v1/services", serviceID),
+			fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+		w.Header().Set("Content-Type", "application/json")
+		service.Status = "ready"
+		json.NewEncoder(w).Encode(service)
+		w.WriteHeader(http.StatusOK)
+	})
+	expectRequest(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal(
+			fmt.Sprintf("%s %s/%s", http.MethodGet, "/provisioning/v1/services", serviceID),
+			fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(&skysql.ErrorResponse{
+			Code: http.StatusNotFound,
+		})
+	})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"skysql": providerserver.NewProtocol6WithError(New("")()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+			resource "skysql_service" default {
+				  service_type   = "transactional"
+				  topology       = "galera"
+				  cloud_provider = "aws"
+				  region         = "us-east-2"
+				  name           = "my-service"
+				  architecture   = "amd64"
+				  nodes          = 3
+				  maxscale_nodes = 1
+				  maxscale_size  = "sky-2x4"
+				  size           = "sky-4x16"
+				  storage        = 100
+				  volume_type    = "io1"
+				  volume_iops    = 3000
+				  ssl_enabled    = true
+				  version        = "10.6.11-6-1"
+				  wait_for_creation = true
+				  wait_for_deletion = true
+				  wait_for_update   = true
+				  deletion_protection = false
+			}
+	            `,
+				Check: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("skysql_service.default", "id", serviceID),
+					resource.TestCheckResourceAttr("skysql_service.default", "maxscale_nodes", "1"),
+				}...),
+			},
+			{
+				Config: `
+			resource "skysql_service" default {
+				  service_type   = "transactional"
+				  topology       = "galera"
+				  cloud_provider = "aws"
+				  region         = "us-east-2"
+				  name           = "my-service"
+				  architecture   = "amd64"
+				  nodes          = 3
+				  maxscale_nodes = 2
+				  maxscale_size  = "sky-2x4"
+				  size           = "sky-4x16"
+				  storage        = 100
+				  volume_type    = "io1"
+				  volume_iops    = 3000
+				  ssl_enabled    = true
+				  version        = "10.6.11-6-1"
+				  wait_for_creation = true
+				  wait_for_deletion = true
+				  wait_for_update   = true
+				  deletion_protection = false
+			}
+	            `,
+				Check: resource.ComposeAggregateTestCheckFunc([]resource.TestCheckFunc{
+					resource.TestCheckResourceAttr("skysql_service.default", "id", serviceID),
+					resource.TestCheckResourceAttr("skysql_service.default", "maxscale_nodes", "2"),
+				}...),
+			},
+		},
+	})
+}

--- a/internal/skysql/client.go
+++ b/internal/skysql/client.go
@@ -369,12 +369,12 @@ func (c *Client) ModifyServiceSize(ctx context.Context, serviceID string, size s
 	})
 }
 
-func (c *Client) ModifyServiceNodeNumber(ctx context.Context, serviceID string, nodes int64) error {
+func (c *Client) ModifyServiceNodeNumber(ctx context.Context, serviceID string, req *provisioning.UpdateServiceNodesNumberRequest) error {
 	return c.doWithPendingRetry(ctx, func() error {
 		resp, err := c.HTTPClient.R().
 			SetHeader("Accept", "application/json").
 			SetContext(ctx).
-			SetBody(&provisioning.UpdateServiceNodesNumberRequest{Nodes: nodes}).
+			SetBody(req).
 			SetError(&ErrorResponse{}).
 			Post("/provisioning/v1/services/" + serviceID + "/nodes")
 		if err != nil {

--- a/internal/skysql/provisioning/update_service_node_number.go
+++ b/internal/skysql/provisioning/update_service_node_number.go
@@ -1,5 +1,6 @@
 package provisioning
 
 type UpdateServiceNodesNumberRequest struct {
-	Nodes int64 `json:"nodes,omitempty"`
+	Nodes         int64  `json:"nodes,omitempty"`
+	MaxscaleNodes *int64 `json:"maxscale_nodes,omitempty"`
 }

--- a/templates/guides/scaling-instance-and-storage.md
+++ b/templates/guides/scaling-instance-and-storage.md
@@ -113,8 +113,36 @@ resource "skysql_service" "default" {
 }
 ```
 
+## Scaling MaxScale Nodes
+
+Replicated topologies that include MaxScale (for example `es-replica` and `galera`) accept a `maxscale_nodes` attribute. Changing its value updates the service in place — for example, going from a single MaxScale node to a redundant pair:
+
+```hcl
+resource "skysql_service" "default" {
+  service_type      = "transactional"
+  topology          = "galera"
+  cloud_provider    = "aws"
+  region            = "us-east-1"
+  name              = "myservice"
+  architecture      = "amd64"
+  nodes             = 3
+  maxscale_nodes    = 2 # was 1
+  maxscale_size     = "sky-2x4"
+  size              = "sky-4x16"
+  storage           = 100
+  ssl_enabled       = true
+  version           = "10.6"
+  wait_for_creation = true
+  wait_for_update   = true
+}
+```
+
+A `maxscale_nodes` change can be combined with a `nodes` change in the same apply; the provider submits them as a single scaling request.
+
+~> **Note:** Valid values are 1 or 2, and MaxScale changes require the Power tier — the same rules that apply when configuring MaxScale at creation. Removing `maxscale_nodes` from the configuration entirely forces the service to be replaced, as does changing `maxscale_size`.
+
 ## Important Notes
 
 - **Set `wait_for_update = true`** to ensure Terraform waits for each scaling operation to complete before proceeding. Without this, Terraform will return immediately after submitting the request.
 - **Scaling is an online operation** — the service remains accessible during scaling, though brief performance impact may occur.
-- **Node count scaling** is also supported via the `nodes` attribute and can be combined with size and storage changes in the same apply.
+- **Node count scaling** is also supported via the `nodes` attribute and can be combined with size, storage, and MaxScale node changes in the same apply.


### PR DESCRIPTION
Port of skysqlinc/terraform-provider-skysql-beta#38.

## Summary
- Changing `maxscale_nodes` on a `skysql_service` now updates the service in place. Previously the provider treated any change to it as requiring the service to be destroyed and recreated.
- The provider sends only the fields that changed: nodes-only changes behave exactly as before, a MaxScale-only change sends just `maxscale_nodes`, and changing `nodes` and `maxscale_nodes` together applies both in a single scaling request.
- Removing `maxscale_nodes` from the configuration still forces replacement, as does changing `maxscale_size`.
- Allowed values and tier requirements are enforced by the API and surface as clear apply-time errors.
- Documentation: a new "Scaling MaxScale Nodes" section in the scaling guide, an updated `maxscale_nodes` attribute description, and a note in the Galera example that MaxScale scaling no longer recreates the cluster.
